### PR TITLE
[frontend] apiリクエストを整理する #7

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -20,6 +20,7 @@ func main() {
 	config.LoadEnv()
 
 	e := echo.New()
+	e.Use(echoMiddleware.CORS())
 	e.Use(echoMiddleware.Logger())
 	e.Use(echoMiddleware.Recover())
 

--- a/backend/internal/repository/user_repository.go
+++ b/backend/internal/repository/user_repository.go
@@ -20,18 +20,19 @@ func CreateUser(user *model.User) error {
 func CreateTmpUser(tmpUser *model.TmpUser) error {
 	var existingUser model.User
 	if err := db.DB.Where("email = ?", tmpUser.Email).First(&existingUser).Error; err == nil {
-
-		var existingTmpUser model.TmpUser
-
-		if err := db.DB.Where("email = ?", tmpUser.Email).First(&existingTmpUser).Error; err == nil {
-			existingTmpUser.VerifyCode = tmpUser.VerifyCode
-			return db.DB.Save(&existingTmpUser).Error
-		}
-		
 		return ErrEmailAlreadyUsed
 	}
+
+	var existingTmpUser model.TmpUser
+	if err := db.DB.Where("email = ?", tmpUser.Email).First(&existingTmpUser).Error; err == nil {
+		existingTmpUser.VerifyCode = tmpUser.VerifyCode
+		existingTmpUser.Password = tmpUser.Password
+		return db.DB.Save(&existingTmpUser).Error
+	}
+
 	return db.DB.Create(tmpUser).Error
 }
+
 
 func UpdateUser(user *model.User) error {
 	return db.DB.Save(user).Error

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -33,7 +33,10 @@ func SignUp(email, password string) error {
 		CreatedAt:  time.Now(),
 	}
 
-	repository.CreateTmpUser(tmpUser)
+	err = repository.CreateTmpUser(tmpUser)
+	if err != nil {
+		return err
+	}
 
 	return util.SendVerificationEmail(email, code)
 }

--- a/backend/internal/util/mail.go
+++ b/backend/internal/util/mail.go
@@ -6,6 +6,8 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/smtp"
+	"net/textproto"
+	"strings"
 )
 
 func SendVerificationEmail(email, code string) error {
@@ -138,5 +140,17 @@ func SmtpSendMail(mailAddress, mailSubject, mailBody string, isHTML bool) error 
 		return err
 	}
 
-	return client.Quit()
+	err = client.Quit()
+	if err != nil {
+		if tpErr, ok := err.(*textproto.Error); ok {
+			if tpErr.Code >= 250 && tpErr.Code < 300 {
+				return nil
+			}
+		}
+		if strings.HasPrefix(err.Error(), "250") {
+			return nil
+		}
+		return err
+	}
+	return nil
 }

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -1,11 +1,17 @@
 import { configureStore } from '@reduxjs/toolkit'
 import counterReducer from '../features/counter/counterSlice'
+import { authApi } from "../features/auth/authApi";
+import authReducer from "../features/auth/authSlice";
 
 export const store = configureStore({
   reducer: {
     counter: counterReducer,
+    auth: authReducer,
+    [authApi.reducerPath]: authApi.reducer,
   },
-})
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(authApi.middleware),
+});
 
 export type RootState = ReturnType<typeof store.getState>
 export type AppDispatch = typeof store.dispatch

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -1,0 +1,6 @@
+const BASE_URL =
+  import.meta.env.MODE === "production"
+    ? "https://your-production-domain.com"
+    : "http://localhost:8081";
+
+export default BASE_URL;

--- a/frontend/src/features/auth/authApi.ts
+++ b/frontend/src/features/auth/authApi.ts
@@ -1,0 +1,52 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import type { RootState } from '../../app/store';
+import BASE_URL from "../../constants/api";
+import type { LoginRequest, AuthResponse, MeResponse, SignupRequest, VerifyRequest } from './types';
+
+export const authApi = createApi({
+  reducerPath: 'authApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: BASE_URL,
+    prepareHeaders: (headers, { getState }) => {
+        const token = (getState() as RootState).auth.token;
+        console.log('TOKEN:', token); // デバッグ用
+        if (token) {
+          headers.set('Authorization', `Bearer ${token}`);
+        }
+        return headers;
+      }
+  }),
+  endpoints: (builder) => ({
+    signup: builder.mutation<void, SignupRequest>({
+      query: (body) => ({
+        url: 'auth/signup',
+        method: 'POST',
+        body,
+      }),
+    }),
+    verify: builder.mutation<void, VerifyRequest>({
+      query: (body) => ({
+        url: 'auth/verify',
+        method: 'POST',
+        body,
+      }),
+    }),
+    login: builder.mutation<AuthResponse, LoginRequest>({
+      query: (body) => ({
+        url: 'auth/login',
+        method: 'POST',
+        body,
+      }),
+    }),
+    getMe: builder.query<MeResponse, void>({
+      query: () => 'api/me',
+    }),
+  }),
+});
+
+export const {
+  useSignupMutation,
+  useVerifyMutation,
+  useLoginMutation,
+  useGetMeQuery,
+} = authApi;

--- a/frontend/src/features/auth/authSlice.ts
+++ b/frontend/src/features/auth/authSlice.ts
@@ -1,0 +1,27 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface AuthState {
+  token: string | null;
+}
+
+const initialState: AuthState = {
+    token: localStorage.getItem('token'),
+};
+
+export const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setToken: (state, action: PayloadAction<string>) => {
+      state.token = action.payload;
+      localStorage.setItem('token', action.payload);
+    },
+    clearToken: (state) => {
+      state.token = null;
+      localStorage.removeItem('token');
+    },
+  },
+});
+
+export const { setToken, clearToken } = authSlice.actions;
+export default authSlice.reducer;

--- a/frontend/src/features/auth/authSlice.ts
+++ b/frontend/src/features/auth/authSlice.ts
@@ -2,26 +2,30 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 interface AuthState {
   token: string | null;
+  email: string | null;
 }
 
 const initialState: AuthState = {
-    token: localStorage.getItem('token'),
+  token: null,
+  email: null,
 };
 
-export const authSlice = createSlice({
+const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
     setToken: (state, action: PayloadAction<string>) => {
       state.token = action.payload;
-      localStorage.setItem('token', action.payload);
     },
-    clearToken: (state) => {
+    setEmail: (state, action: PayloadAction<string>) => {
+      state.email = action.payload;
+    },
+    clearAuth: (state) => {
       state.token = null;
-      localStorage.removeItem('token');
+      state.email = null;
     },
   },
 });
 
-export const { setToken, clearToken } = authSlice.actions;
+export const { setToken, setEmail, clearAuth } = authSlice.actions;
 export default authSlice.reducer;

--- a/frontend/src/features/auth/types.ts
+++ b/frontend/src/features/auth/types.ts
@@ -1,0 +1,24 @@
+export interface LoginRequest {
+    email: string;
+    password: string;
+  }
+  
+  export interface SignupRequest {
+    email: string;
+    password: string;
+  }
+  
+  export interface VerifyRequest {
+    email: string;
+    code: string;
+  }
+  
+  export interface AuthResponse {
+    token: string;
+  }
+  
+  export interface MeResponse {
+    id: number;
+    email: string;
+  }
+  

--- a/frontend/src/features/counter/Counter.tsx
+++ b/frontend/src/features/counter/Counter.tsx
@@ -1,20 +1,29 @@
-import { useSelector, useDispatch } from 'react-redux'
-import { RootState, AppDispatch } from '../../app/store'
-import { increment, decrement, reset } from './counterSlice'
+import { useSelector, useDispatch } from "react-redux";
+import { RootState, AppDispatch } from "../../app/store";
+import { increment, decrement, reset } from "./counterSlice";
+import { useGetMeQuery } from "../auth/authApi";
 
 const Counter = () => {
-  const count = useSelector((state: RootState) => state.counter.value)
-  const dispatch = useDispatch<AppDispatch>()
+  const count = useSelector((state: RootState) => state.counter.value);
+  const dispatch = useDispatch<AppDispatch>();
+
+  const { data, isLoading, error } = useGetMeQuery();
+
+  if (isLoading) return <div>読み込み中...</div>;
+  if (error) return <div>エラーが発生しました</div>;
 
   return (
-    <div style={{ textAlign: 'center' }}>
+    <div style={{ textAlign: "center" }}>
+      <div>
+        ようこそ、{data?.email} さん（ID: {data?.id}）
+      </div>
       <h2>Reduxカウンター</h2>
       <p>今の値: {count}</p>
       <button onClick={() => dispatch(increment())}>+1</button>
       <button onClick={() => dispatch(decrement())}>-1</button>
       <button onClick={() => dispatch(reset())}>リセット</button>
     </div>
-  )
-}
+  );
+};
 
-export default Counter
+export default Counter;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import { useLoginMutation } from '../features/auth/authApi';
+import { useDispatch } from 'react-redux';
+import { setToken } from '../features/auth/authSlice';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  TextField,
+  Typography,
+  Link as MuiLink,
+  CircularProgress,
+} from '@mui/material';
+import { Link, useNavigate } from 'react-router-dom';
+
+export default function Login() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [login, { isLoading, error }] = useLoginMutation();
+  const [isSubmitting, setIsSubmitting] = useState(false); // ← 連打防止用
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    try {
+      const res = await login({ email, password }).unwrap();
+      dispatch(setToken(res.token));
+      navigate('/');
+    } catch (err) {
+      console.error('Login failed:', err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Box
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      minHeight="100vh"
+      bgcolor="background.default"
+    >
+      <Card sx={{ maxWidth: 400, width: '100%', p: 2 }}>
+        <CardContent>
+          <Typography variant="h5" component="div" mb={2}>
+            ログイン
+          </Typography>
+          <Box component="form" onSubmit={handleSubmit} noValidate>
+            <TextField
+              label="メールアドレス"
+              type="email"
+              fullWidth
+              margin="normal"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+            <TextField
+              label="パスワード"
+              type="password"
+              fullWidth
+              margin="normal"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+            {error && (
+              <Typography color="error" variant="body2" mt={1}>
+                ログインに失敗しました
+              </Typography>
+            )}
+            <Button
+              type="submit"
+              variant="contained"
+              color="primary"
+              fullWidth
+              sx={{ mt: 2 }}
+              disabled={isLoading || isSubmitting} // ← ローディング中 & 二重送信防止
+            >
+              {(isLoading || isSubmitting) ? (
+                <CircularProgress size={24} />
+              ) : (
+                'ログイン'
+              )}
+            </Button>
+          </Box>
+          <Box mt={2} textAlign="center">
+            <MuiLink component={Link} to="/signup" underline="hover">
+              アカウントをお持ちでない方はこちら
+            </MuiLink>
+          </Box>
+        </CardContent>
+      </Card>
+    </Box>
+  );
+}

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { useSignupMutation } from '../features/auth/authApi';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  TextField,
+  Typography,
+  CircularProgress,
+  Link,
+} from '@mui/material';
+import { Link as RouterLink, useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { setEmail } from '../features/auth/authSlice';
+
+export default function Signup() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const [signup, { isLoading, error }] = useSignupMutation();
+  const [email, setEmailInput] = useState('');
+  const [password, setPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    try {
+      await signup({ email, password }).unwrap();
+      dispatch(setEmail(email));
+      navigate('/verify');
+    } catch (err) {
+      console.error('Signup failed:', err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Box
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      minHeight="100vh"
+      bgcolor="background.default"
+    >
+      <Card sx={{ maxWidth: 400, width: '100%', p: 2 }}>
+        <CardContent>
+          <Typography variant="h5" component="div" mb={2}>
+            アカウント作成
+          </Typography>
+          <Box component="form" onSubmit={handleSubmit} noValidate>
+            <TextField
+              label="メールアドレス"
+              type="email"
+              fullWidth
+              margin="normal"
+              value={email}
+              onChange={(e) => setEmailInput(e.target.value)}
+              required
+            />
+            <TextField
+              label="パスワード"
+              type="password"
+              fullWidth
+              margin="normal"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+            {error && (
+              <Typography color="error" variant="body2" mt={1}>
+                登録に失敗しました
+              </Typography>
+            )}
+            <Button
+              type="submit"
+              variant="contained"
+              color="primary"
+              fullWidth
+              sx={{ mt: 2 }}
+              disabled={isLoading || isSubmitting}
+            >
+              {(isLoading || isSubmitting) ? (
+                <CircularProgress size={24} />
+              ) : (
+                '登録'
+              )}
+            </Button>
+          </Box>
+          <Box mt={2}>
+            <Typography variant="body2" align="center">
+              すでにアカウントをお持ちの方は{' '}
+              <Link component={RouterLink} to="/login">
+                ログイン
+              </Link>
+            </Typography>
+          </Box>
+        </CardContent>
+      </Card>
+    </Box>
+  );
+}

--- a/frontend/src/pages/Verify.tsx
+++ b/frontend/src/pages/Verify.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { useVerifyMutation } from '../features/auth/authApi';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  TextField,
+  Typography,
+  CircularProgress,
+} from '@mui/material';
+import { useSelector } from 'react-redux';
+import type { RootState } from '../app/store';
+import { useNavigate } from 'react-router-dom';
+
+export default function Verify() {
+  const navigate = useNavigate();
+  const email = useSelector((state: RootState) => state.auth.email);
+  const [verify, { isLoading, error }] = useVerifyMutation();
+  const [code, setCode] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email) {
+      alert('メールアドレスが未設定です。先にサインアップしてください。');
+      navigate('/signup');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await verify({ email, code }).unwrap();
+      navigate('/login');
+    } catch (err) {
+      console.error('Verify failed:', err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Box
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      minHeight="100vh"
+      bgcolor="background.default"
+    >
+      <Card sx={{ maxWidth: 400, width: '100%', p: 2 }}>
+        <CardContent>
+          <Typography variant="h5" component="div" mb={2}>
+            認証コードの確認
+          </Typography>
+          <Box component="form" onSubmit={handleSubmit} noValidate>
+            <TextField
+              label="認証コード"
+              type="text"
+              fullWidth
+              margin="normal"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              required
+            />
+            {error && (
+              <Typography color="error" variant="body2" mt={1}>
+                認証に失敗しました
+              </Typography>
+            )}
+            <Button
+              type="submit"
+              variant="contained"
+              color="primary"
+              fullWidth
+              sx={{ mt: 2 }}
+              disabled={isLoading || isSubmitting}
+            >
+              {(isLoading || isSubmitting) ? (
+                <CircularProgress size={24} />
+              ) : (
+                '認証する'
+              )}
+            </Button>
+          </Box>
+        </CardContent>
+      </Card>
+    </Box>
+  );
+}

--- a/frontend/src/route.tsx
+++ b/frontend/src/route.tsx
@@ -1,21 +1,36 @@
-import { RouteObject } from 'react-router-dom'
-import ReduxSample from './pages/ReduxSample'
-import NotFound from './pages/NotFound'
-import { Navigate } from 'react-router-dom'
+import { RouteObject } from "react-router-dom";
+import ReduxSample from "./pages/ReduxSample";
+import NotFound from "./pages/NotFound";
+import Login from "./pages/Login";
+import { Navigate } from "react-router-dom";
+import Signup from "./pages/Signup";
+import Verify from "./pages/Verify";
 
 const routes: RouteObject[] = [
   {
-    path: '/',
+    path: "/",
     element: <ReduxSample />,
   },
   {
-    path: '/error/404',
+    path: "/login",
+    element: <Login />,
+  },
+  {
+    path: "/signup",
+    element: <Signup />,
+  },
+  {
+    path: "/verify",
+    element: <Verify />,
+  },
+  {
+    path: "/error/404",
     element: <NotFound />,
   },
   {
-    path: '*',
+    path: "*",
     element: <Navigate to="/error/404" replace />,
   },
-]
+];
 
-export default routes
+export default routes;


### PR DESCRIPTION
  - Redux Toolkitの createApi（RTK Query）を使ってログイン部分を実装