### PR TITLE
[frontend] ヘッダーを作る #10

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@mui/icons-material": "^7.0.2",
         "@mui/material": "^7.0.2",
         "@reduxjs/toolkit": "^2.7.0",
         "react": "^19.0.0",
@@ -1095,6 +1096,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.0.2.tgz",
+      "integrity": "sha512-Bo57PFLOqXOqPNrXjd8AhzH5s6TCsNUQbvnQ0VKZ8D+lIlteqKnrk/O1luMJUc/BXONK7BfIdTdc7qOnXYbMdw==",
+      "dependencies": {
+        "@babel/runtime": "^7.27.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^7.0.2",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@mui/icons-material": "^7.0.2",
     "@mui/material": "^7.0.2",
     "@reduxjs/toolkit": "^2.7.0",
     "react": "^19.0.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,12 @@
-import { useRoutes } from 'react-router-dom'
-import routes from './route'
+import { useRoutes } from "react-router-dom";
+import AppHeader from "./components/AppHeader";
+import routes from "./route";
 
 export default function App() {
-  return useRoutes(routes)
+  return (
+    <>
+      <AppHeader />
+      {useRoutes(routes)}
+    </>
+  );
 }

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -1,0 +1,113 @@
+import {
+  AppBar,
+  Toolbar,
+  Typography,
+  Button,
+  Box,
+  IconButton,
+  useTheme,
+  Stack,
+} from "@mui/material";
+import HomeIcon from "@mui/icons-material/Home";
+import LoginIcon from "@mui/icons-material/Login";
+import LogoutIcon from "@mui/icons-material/Logout";
+import { useNavigate } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import { clearAuth } from "../features/auth/authSlice";
+import { RootState } from "../app/store";
+
+
+const AppHeader = () => {
+  const navigate = useNavigate();
+  const theme = useTheme();
+  const dispatch = useDispatch();
+  const token = useSelector((state: RootState) => state.auth.token);
+
+  const handleLogin = () => {
+    navigate("/login");
+  };
+
+  const handleLogout = () => {
+    dispatch(clearAuth());
+    navigate("/");
+  };
+
+  const handleHomeClick = () => {
+    navigate("/");
+  };
+
+  return (
+    <AppBar
+      position="static"
+      elevation={0}
+      sx={{
+        backgroundColor: theme.palette.primary.main,
+        color: theme.palette.text.primary,
+        borderBottom: `1px solid ${theme.palette.divider}`,
+        px: 3,
+      }}
+    >
+      <Toolbar sx={{ minHeight: 64 }}>
+        <IconButton
+          onClick={handleHomeClick}
+          sx={{
+            color: theme.palette.text.primary,
+            "&:hover": {
+              backgroundColor: `${theme.palette.primary.main}10`,
+            },
+          }}
+        >
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <HomeIcon />
+            <Typography
+              variant="h6"
+              sx={{ fontWeight: 600, userSelect: "none" }}
+            >
+              HistoryHub
+            </Typography>
+          </Stack>
+        </IconButton>
+
+        <Box sx={{ flexGrow: 1 }} />
+
+        {token ? (
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleLogout}
+            startIcon={<LogoutIcon />}
+            sx={{
+              borderRadius: 2,
+              textTransform: "none",
+              boxShadow: "none",
+              "&:hover": {
+                boxShadow: `0 0 0 2px ${theme.palette.primary.main}33`,
+              },
+            }}
+          >
+            ログアウト
+          </Button>
+        ) : (
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleLogin}
+            startIcon={<LoginIcon />}
+            sx={{
+              borderRadius: 2,
+              textTransform: "none",
+              boxShadow: "none",
+              "&:hover": {
+                boxShadow: `0 0 0 2px ${theme.palette.primary.main}33`,
+              },
+            }}
+          >
+            ログイン
+          </Button>
+        )}
+      </Toolbar>
+    </AppBar>
+  );
+};
+
+export default AppHeader;

--- a/frontend/src/features/auth/authApi.ts
+++ b/frontend/src/features/auth/authApi.ts
@@ -9,7 +9,6 @@ export const authApi = createApi({
     baseUrl: BASE_URL,
     prepareHeaders: (headers, { getState }) => {
         const token = (getState() as RootState).auth.token;
-        console.log('TOKEN:', token); // デバッグ用
         if (token) {
           headers.set('Authorization', `Bearer ${token}`);
         }

--- a/frontend/src/features/auth/authSlice.ts
+++ b/frontend/src/features/auth/authSlice.ts
@@ -16,6 +16,7 @@ const authSlice = createSlice({
   reducers: {
     setToken: (state, action: PayloadAction<string>) => {
       state.token = action.payload;
+      localStorage.setItem("token", state.token)
     },
     setEmail: (state, action: PayloadAction<string>) => {
       state.email = action.payload;
@@ -23,6 +24,7 @@ const authSlice = createSlice({
     clearAuth: (state) => {
       state.token = null;
       state.email = null;
+      localStorage.removeItem("token");
     },
   },
 });

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -41,7 +41,7 @@ export default function Login() {
       display="flex"
       justifyContent="center"
       alignItems="center"
-      minHeight="100vh"
+      minHeight="85vh"
       bgcolor="background.default"
     >
       <Card sx={{ maxWidth: 400, width: '100%', p: 2 }}>

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -8,9 +8,9 @@ import {
   TextField,
   Typography,
   CircularProgress,
-  Link,
+  Link as MuiLink,
 } from '@mui/material';
-import { Link as RouterLink, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { setEmail } from '../features/auth/authSlice';
 
@@ -41,7 +41,7 @@ export default function Signup() {
       display="flex"
       justifyContent="center"
       alignItems="center"
-      minHeight="100vh"
+      minHeight="85vh"
       bgcolor="background.default"
     >
       <Card sx={{ maxWidth: 400, width: '100%', p: 2 }}>
@@ -84,17 +84,14 @@ export default function Signup() {
               {(isLoading || isSubmitting) ? (
                 <CircularProgress size={24} />
               ) : (
-                '登録'
+                '作成'
               )}
             </Button>
           </Box>
           <Box mt={2}>
-            <Typography variant="body2" align="center">
-              すでにアカウントをお持ちの方は{' '}
-              <Link component={RouterLink} to="/login">
-                ログイン
-              </Link>
-            </Typography>
+            <MuiLink component={Link} to="/login" underline="hover">
+              すでにアカウントお持ちの方はこちら
+            </MuiLink>
           </Box>
         </CardContent>
       </Card>

--- a/frontend/src/pages/Verify.tsx
+++ b/frontend/src/pages/Verify.tsx
@@ -44,7 +44,7 @@ export default function Verify() {
       display="flex"
       justifyContent="center"
       alignItems="center"
-      minHeight="100vh"
+      minHeight="85vh"
       bgcolor="background.default"
     >
       <Card sx={{ maxWidth: 400, width: '100%', p: 2 }}>


### PR DESCRIPTION
  - ヘッダーコンポーネントの作成
  - login、signup、verify画面の配置をヘッダーに合わせて修正
  - signup画面のloginへのリンクを修正
  - tokenのstorek管理時にローカルストレージへの繁栄を行う
  - tokenのデバックコード削除